### PR TITLE
Improve installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ which is available under the BSD 3-Clause License.
 * pyyaml >= 5.3.1
 * lightgbm >= 2.3.1
 
-On Mac, you will also need to install libomp:
-
-```bash
-brew install libomp
-```
+On Mac, you will also need to install libomp: `brew install libomp`.
 
 ### Optional
 * gurobi >= 9.0.1

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ which is available under the BSD 3-Clause License.
 * pyyaml >= 5.3.1
 * lightgbm >= 2.3.1
 
+On Mac, you will also need to install libomp:
+
+```bash
+brew install libomp
+```
+
 ### Optional
 * gurobi >= 9.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.18.4
 scikit-learn>=0.21.3
-pyyaml>=5.3.1
+PyYAML>=5.3.1
 lightgbm>=2.3.1

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ version_path = project_root / 'entmoot' / '__version__.py'
 with version_path.open() as f:
     exec(f.read(), about)
 
+requirements_path = project_root / 'requirements.txt'
+with requirements_path.open() as f:
+    requirements = f.readlines()  
+
 setup(
     name='entmoot',
     author=about['__author__'],
@@ -16,16 +20,5 @@ setup(
     version=about['__version__'],
     url='https://github.com/cog-imperial/entmoot',
     packages=find_packages(exclude=['tests','docs']),
-    install_requires=[
-        'numpy>=1.18.4'
-        'scikit-learn>=0.21.3'
-        'pyyaml>=5.3.1'
-        'lightgbm>=2.3.1'
-    ],
-    setup_requires=[
-        'numpy>=1.18.4'
-        'scikit-learn>=0.21.3'
-        'pyyaml>=5.3.1'
-        'lightgbm>=2.3.1'
-    ]
+    install_requires=requirements
 )


### PR DESCRIPTION
Currently, the installation of ENTMOOT doesn't work. For example, this is the result of an attempt at installation:
```Bash
[SolverProblemError]
Because entmoot (0.1.2) depends on numpy (>=1.18.4scikit-learn)
 and no versions of entmoot match >0.1.2,<0.2.0, entmoot (>=0.1.2,<0.2.0) requires numpy (>=1.18.4scikit-learn).
So, because summit depends on both numpy (1.18.0) and entmoot (^0.1.2), version solving failed.
```
This PR corrects the typos to make the installation work.

Also, a note about installating libomp is added to complete the installation instructions on Mac OS X (see here for more [info](https://github.com/microsoft/LightGBM/tree/master/python-package#install-from-pypi-using-pip)).

Could the pypi wheel also be updated?
