### PR TITLE
Typed parameters of Enting model

### DIFF
--- a/docs/notebooks/multi_obj_pareto.ipynb
+++ b/docs/notebooks/multi_obj_pareto.ipynb
@@ -45,10 +45,31 @@
     "\n",
     "# sample data\n",
     "rnd_sample = problem_config.get_rnd_sample_list(num_samples=20)\n",
-    "testfunc_evals = eval_multi_obj_cat_testfunc(rnd_sample, n_obj=number_objectives)\n",
+    "testfunc_evals = eval_multi_obj_cat_testfunc(rnd_sample, n_obj=number_objectives)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "180e8e4b",
+   "metadata": {},
+   "source": [
+    "Model parameters can be defined in a few ways:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63286741",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from entmoot import EntingParams, UncParams, TrainParams, TreeTrainParams\n",
     "\n",
-    "      \n",
+    "# all three of the below `params` are valid arguments for Enting\n",
     "params = {\"unc_params\": {\"dist_metric\": \"l1\", \"acq_sense\": \"exploration\"}}\n",
+    "params = EntingParams(**params)\n",
+    "params = EntingParams(unc_params=UncParams(dist_metric=\"l1\", acq_sense=\"exploration\"))\n",
+    "\n",
     "enting = Enting(problem_config, params=params)\n",
     "# fit tree ensemble\n",
     "enting.fit(rnd_sample, testfunc_evals)"
@@ -101,9 +122,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "enttest",
    "language": "python",
-   "name": "python3"
+   "name": "enttest"
   },
   "language_info": {
    "codemirror_mode": {
@@ -115,7 +136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/entmoot/__init__.py
+++ b/entmoot/__init__.py
@@ -2,3 +2,4 @@ from entmoot.problem_config import ProblemConfig
 from entmoot.models.enting import Enting
 from entmoot.optimizers.gurobi_opt import GurobiOptimizer
 from entmoot.optimizers.pyomo_opt import PyomoOptimizer
+from entmoot.models.model_params import EntingParams, UncParams, TreeTrainParams, TrainParams

--- a/entmoot/models/enting.py
+++ b/entmoot/models/enting.py
@@ -54,35 +54,20 @@ class Enting(BaseModel):
         if params is None:
             params = {}
         if isinstance(params, dict):
-            params = EntingParams.fromdict(params)
-
-        # this is temporary - just to avoid breaking the code!
-        # params = asdict(params)
+            params = EntingParams(**params)
 
         self._problem_config = problem_config
 
-        # check params values
-        # tree_training_params = params.get("tree_train_params", {})
-        tree_training_params = params.tree_train_params
-
         # initialize mean model
         self.mean_model = TreeEnsemble(
-            problem_config=problem_config, params=tree_training_params
+            problem_config=problem_config, params=params.tree_train_params
         )
 
         # initialize unc model
-        # unc_params = params.get("unc_params", {})
         unc_params = params.unc_params
         self._acq_sense = unc_params.acq_sense
-        assert self._acq_sense in (
-            "exploration",
-            "penalty",
-        ), f"Pick 'acq_sense' '{self._acq_sense}' in '('exploration', 'penalty')'."
 
         self._beta = unc_params.beta
-        assert (
-            self._beta >= 0.0
-        ), f"Value for 'beta' is {self._beta} but must be '>= 0.0'."
 
         if self._acq_sense == "exploration":
             self._beta = -self._beta

--- a/entmoot/models/enting.py
+++ b/entmoot/models/enting.py
@@ -4,7 +4,10 @@ from entmoot.models.mean_models.tree_ensemble import TreeEnsemble
 from entmoot.models.uncertainty_models.distance_based_uncertainty import (
     DistanceBasedUncertainty,
 )
+from entmoot.utils import EntingParams
+from dataclasses import asdict
 import numpy as np
+from typing import Union
 
 
 class Enting(BaseModel):
@@ -47,9 +50,14 @@ class Enting(BaseModel):
             X_opt_pyo, _, _ = opt_pyo.solve(enting)
     """
 
-    def __init__(self, problem_config: ProblemConfig, params: dict = None):
+    def __init__(self, problem_config: ProblemConfig, params: Union[EntingParams, dict]):
         if params is None:
             params = {}
+        if isinstance(params, dict):
+            params = EntingParams.from_dict(params)
+
+        # this is temporary - just to avoid breaking the code!
+        params = asdict(params)
 
         self._problem_config = problem_config
 

--- a/entmoot/models/enting.py
+++ b/entmoot/models/enting.py
@@ -4,7 +4,7 @@ from entmoot.models.mean_models.tree_ensemble import TreeEnsemble
 from entmoot.models.uncertainty_models.distance_based_uncertainty import (
     DistanceBasedUncertainty,
 )
-from entmoot.utils import EntingParams
+from entmoot.models.model_params import EntingParams
 from dataclasses import asdict
 import numpy as np
 from typing import Union
@@ -50,19 +50,20 @@ class Enting(BaseModel):
             X_opt_pyo, _, _ = opt_pyo.solve(enting)
     """
 
-    def __init__(self, problem_config: ProblemConfig, params: Union[EntingParams, dict]):
+    def __init__(self, problem_config: ProblemConfig, params: Union[EntingParams, dict, None]):
         if params is None:
             params = {}
         if isinstance(params, dict):
-            params = EntingParams.from_dict(params)
+            params = EntingParams.fromdict(params)
 
         # this is temporary - just to avoid breaking the code!
-        params = asdict(params)
+        # params = asdict(params)
 
         self._problem_config = problem_config
 
         # check params values
-        tree_training_params = params.get("tree_train_params", {})
+        # tree_training_params = params.get("tree_train_params", {})
+        tree_training_params = params.tree_train_params
 
         # initialize mean model
         self.mean_model = TreeEnsemble(
@@ -70,14 +71,15 @@ class Enting(BaseModel):
         )
 
         # initialize unc model
-        unc_params = params.get("unc_params", {})
-        self._acq_sense = unc_params.get("acq_sense", "exploration")
+        # unc_params = params.get("unc_params", {})
+        unc_params = params.unc_params
+        self._acq_sense = unc_params.acq_sense
         assert self._acq_sense in (
             "exploration",
             "penalty",
         ), f"Pick 'acq_sense' '{self._acq_sense}' in '('exploration', 'penalty')'."
 
-        self._beta = unc_params.get("beta", 1.96)
+        self._beta = unc_params.beta
         assert (
             self._beta >= 0.0
         ), f"Value for 'beta' is {self._beta} but must be '>= 0.0'."

--- a/entmoot/models/mean_models/tree_ensemble.py
+++ b/entmoot/models/mean_models/tree_ensemble.py
@@ -1,45 +1,31 @@
 from entmoot.models.base_model import BaseModel
 from entmoot.models.mean_models.lgbm_utils import read_lgbm_tree_model_dict
 from entmoot.models.mean_models.meta_tree_ensemble import MetaTreeModel
+from entmoot.models.model_params import TreeTrainParams
 import warnings
+from typing import Union
+from dataclasses import asdict
 import numpy as np
 
 
 class TreeEnsemble(BaseModel):
-    def __init__(self, problem_config, params=None):
+    def __init__(self, problem_config, params:Union[TreeTrainParams, dict, None]=None):
         if params is None:
             params = {}
+        if isinstance(params, dict):
+            params = TreeTrainParams.fromdict(params)
 
         self._problem_config = problem_config
-        self._train_lib = params.get("train_lib", "lgbm")
+        self._train_lib = params.train_lib
         self._rnd_seed = problem_config.rnd_seed
 
         assert self._train_lib in ("lgbm"), (
             "Parameter 'train_lib' for tree ensembles needs to be " "in '('lgbm')'."
         )
 
-        if "train_params" not in params:
-            # default training params
-            warnings.warn(
-                "No 'train_params' for tree ensemble training specified. "
-                "Switch training to default params!"
-            )
-
-            self._train_params = {
-                "objective": "regression",
-                "metric": "rmse",
-                "boosting": "gbdt",
-                "num_boost_round": 100,
-                "max_depth": 3,
-                "min_data_in_leaf": 1,
-                "min_data_per_group": 1,
-                "verbose": -1,
-            }
-
-            if self._rnd_seed is not None:
-                self._train_params["random_state"] = self._rnd_seed
-        else:
-            self._train_params = params["train_params"]
+        self._train_params = asdict(params.train_params)
+        if self._rnd_seed is not None:
+            self._train_params["random_state"] = self._rnd_seed
 
         self._tree_dict = None
         self._meta_tree_dict = {}

--- a/entmoot/models/mean_models/tree_ensemble.py
+++ b/entmoot/models/mean_models/tree_ensemble.py
@@ -9,19 +9,15 @@ import numpy as np
 
 
 class TreeEnsemble(BaseModel):
-    def __init__(self, problem_config, params:Union[TreeTrainParams, dict, None]=None):
+    def __init__(self, problem_config, params: Union[TreeTrainParams, dict, None] = None):
         if params is None:
             params = {}
         if isinstance(params, dict):
-            params = TreeTrainParams.fromdict(params)
+            params = TreeTrainParams(**params)
 
         self._problem_config = problem_config
         self._train_lib = params.train_lib
         self._rnd_seed = problem_config.rnd_seed
-
-        assert self._train_lib in ("lgbm"), (
-            "Parameter 'train_lib' for tree ensembles needs to be " "in '('lgbm')'."
-        )
 
         self._train_params = asdict(params.train_params)
         if self._rnd_seed is not None:

--- a/entmoot/models/model_params.py
+++ b/entmoot/models/model_params.py
@@ -1,0 +1,60 @@
+"""Dataclasses containing the parameters for Enting models"""
+
+from typing import Literal
+from dataclasses import dataclass, field
+
+@dataclass
+class UncParams:
+    beta: float = 1.96
+    bound_coeff: float = 0.5
+    acq_sense: Literal["exploration", "penalty"] = "exploration"
+    dist_trafo: Literal["normal", "standard"] = "normal"
+    dist_metric: Literal["euclidean_squared", "l1", "l2"] = "euclidean_squared"
+    cat_metric: Literal["overlap", "of", "goodall4"] = "overlap"
+
+    def __post_init__(self):
+        if self.beta < 0.0:
+            raise ValueError(f"Value for 'beta' is {self.beta} but must be '>= 0.0'.")
+
+@dataclass
+class TrainParams:
+    # lightgbm training hyperparameters
+    objective: str = "regression"
+    metric: str = "rmse"
+    boosting: str = "gbdt"
+    num_boost_round: int = 100
+    max_depth: int = 3
+    min_data_in_leaf: int = 1
+    min_data_per_group: int = 1
+    verbose: int = -1
+
+
+@dataclass
+class TreeTrainParams:
+    train_params: "TrainParams" = field(default_factory=TrainParams)
+    train_lib: Literal["lgbm"] = "lgbm"
+
+    @staticmethod
+    def fromdict(d: dict):
+        d_train_params = d.get("train_params", {})
+        d_tree_train_params = {k: v for k, v in d.items() if k!="train_params"}
+        return TreeTrainParams(
+            train_params=TrainParams(**d_train_params),
+            **d_tree_train_params
+        )
+
+
+@dataclass
+class EntingParams:
+    unc_params: "UncParams" = field(default_factory=UncParams)
+    tree_train_params: "TreeTrainParams" = field(default_factory=TreeTrainParams)
+
+    @staticmethod
+    def fromdict(d: dict):
+        d_unc_params = d.get("unc_params", {})
+        d_tree_train_params = d.get("tree_train_params", {})
+
+        return EntingParams(
+            unc_params=UncParams(**d_unc_params),
+            tree_train_params=TreeTrainParams.fromdict(d_tree_train_params)
+        )

--- a/entmoot/models/model_params.py
+++ b/entmoot/models/model_params.py
@@ -47,7 +47,8 @@ class TreeTrainParams:
     train_lib: Literal["lgbm"] = "lgbm"
 
     def __post_init__(self):
-        self.train_params = TrainParams(**self.train_params)
+        if isinstance(self.train_params, dict):
+            self.train_params = TrainParams(**self.train_params)
         
         if self.train_lib not in ("lgbm",):
             raise ParamValidationError(
@@ -65,5 +66,8 @@ class EntingParams:
     tree_train_params: "TreeTrainParams" = field(default_factory=dict)
     
     def __post_init__(self):
-        self.unc_params = UncParams(**self.unc_params)
-        self.tree_train_params = TreeTrainParams(**self.tree_train_params)
+        if isinstance(self.unc_params, dict):
+            self.unc_params = UncParams(**self.unc_params)
+
+        if isinstance(self.tree_train_params, dict):
+            self.tree_train_params = TreeTrainParams(**self.tree_train_params)

--- a/entmoot/utils.py
+++ b/entmoot/utils.py
@@ -1,4 +1,6 @@
 from collections import namedtuple
+from dataclasses import dataclass
+from typing import Literal
 import numpy as np
 from scipy.special import comb
 
@@ -7,6 +9,37 @@ OptResult = namedtuple(
     "OptResult",
     ["opt_point", "opt_val", "mu_unscaled", "unc_unscaled", "active_leaf_enc"],
 )
+
+
+@dataclass
+class EntingParams:
+    unc_params: "UncParams" = None
+    tree_train_params: "TreeTrainParams" = None
+
+@dataclass
+class UncParams:
+    beta: float = 1.96 # >0
+    acq_sense: Literal["exploration", "penalty"] = "exploration"
+    dist_trafo: Literal["normal", "standard"] = "normal"
+    dist_metric: Literal["euclidean_squared", "l1", "l2"] = "euclidean_squared"
+    cat_metric: Literal["overlap", "of", "goodall4"] = "overlap"
+
+@dataclass
+class TreeTrainParams:
+    train_params: "TrainParams"
+    train_lib: Literal["lgbm"] = "lgbm"
+
+@dataclass
+class TrainParams:
+    # lightgbm training hyperparameters
+    objective: str = "regression"
+    metric: str = "rmse"
+    boosting: str = "gbdt"
+    num_boost_round: int = 100
+    max_depth: int = 3
+    min_data_in_leaf: int = 1
+    min_data_per_group: int = 1
+    verbose: int = -1
 
 
 def grid(dimension: int, levels: int) -> np.ndarray:

--- a/entmoot/utils.py
+++ b/entmoot/utils.py
@@ -11,56 +11,6 @@ OptResult = namedtuple(
 )
 
 
-
-@dataclass
-class UncParams:
-    beta: float = 1.96 # >0
-    acq_sense: Literal["exploration", "penalty"] = "exploration"
-    dist_trafo: Literal["normal", "standard"] = "normal"
-    dist_metric: Literal["euclidean_squared", "l1", "l2"] = "euclidean_squared"
-    cat_metric: Literal["overlap", "of", "goodall4"] = "overlap"
-
-@dataclass
-class TrainParams:
-    # lightgbm training hyperparameters
-    objective: str = "regression"
-    metric: str = "rmse"
-    boosting: str = "gbdt"
-    num_boost_round: int = 100
-    max_depth: int = 3
-    min_data_in_leaf: int = 1
-    min_data_per_group: int = 1
-    verbose: int = -1
-
-
-@dataclass
-class TreeTrainParams:
-    train_params: "TrainParams" = field(default_factory=TrainParams)
-    train_lib: Literal["lgbm"] = "lgbm"
-
-
-@dataclass
-class EntingParams:
-    unc_params: "UncParams" = field(default_factory=UncParams)
-    tree_train_params: "TreeTrainParams" = field(default_factory=TreeTrainParams)
-
-    @staticmethod
-    def from_dict(d: dict):
-        d_unc_params = d.get("unc_params", {})
-        d_tree_train_params = d.get("tree_train_params", {})
-        d_train_params = d_tree_train_params.get("train_params", {})
-        d_tree_train_params = {k: v for k, v in d_tree_train_params.items() if k!="train_params"}
-
-        return EntingParams(
-            unc_params=UncParams(**d_unc_params),
-            tree_train_params=TreeTrainParams(
-                train_params=TrainParams(**d_train_params),
-                **d_tree_train_params
-            )
-        )
-
-
-
 def grid(dimension: int, levels: int) -> np.ndarray:
     """Construct a regular grid on the unit simplex.
 

--- a/entmoot/utils.py
+++ b/entmoot/utils.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 import numpy as np
 from scipy.special import comb
@@ -11,10 +11,6 @@ OptResult = namedtuple(
 )
 
 
-@dataclass
-class EntingParams:
-    unc_params: "UncParams" = None
-    tree_train_params: "TreeTrainParams" = None
 
 @dataclass
 class UncParams:
@@ -23,11 +19,6 @@ class UncParams:
     dist_trafo: Literal["normal", "standard"] = "normal"
     dist_metric: Literal["euclidean_squared", "l1", "l2"] = "euclidean_squared"
     cat_metric: Literal["overlap", "of", "goodall4"] = "overlap"
-
-@dataclass
-class TreeTrainParams:
-    train_params: "TrainParams"
-    train_lib: Literal["lgbm"] = "lgbm"
 
 @dataclass
 class TrainParams:
@@ -40,6 +31,34 @@ class TrainParams:
     min_data_in_leaf: int = 1
     min_data_per_group: int = 1
     verbose: int = -1
+
+
+@dataclass
+class TreeTrainParams:
+    train_params: "TrainParams" = field(default_factory=TrainParams)
+    train_lib: Literal["lgbm"] = "lgbm"
+
+
+@dataclass
+class EntingParams:
+    unc_params: "UncParams" = field(default_factory=UncParams)
+    tree_train_params: "TreeTrainParams" = field(default_factory=TreeTrainParams)
+
+    @staticmethod
+    def from_dict(d: dict):
+        d_unc_params = d.get("unc_params", {})
+        d_tree_train_params = d.get("tree_train_params", {})
+        d_train_params = d_tree_train_params.get("train_params", {})
+        d_tree_train_params = {k: v for k, v in d_tree_train_params.items() if k!="train_params"}
+
+        return EntingParams(
+            unc_params=UncParams(**d_unc_params),
+            tree_train_params=TreeTrainParams(
+                train_params=TrainParams(**d_train_params),
+                **d_tree_train_params
+            )
+        )
+
 
 
 def grid(dimension: int, levels: int) -> np.ndarray:

--- a/tests/test_consistency_gurobi.py
+++ b/tests/test_consistency_gurobi.py
@@ -4,6 +4,7 @@ import random
 import math
 
 from entmoot import Enting, ProblemConfig, GurobiOptimizer
+from entmoot.models.model_params import EntingParams, UncParams, TreeTrainParams, TrainParams
 from entmoot.benchmarks import (
     build_multi_obj_categorical_problem,
     eval_multi_obj_cat_testfunc,
@@ -69,14 +70,14 @@ def run_gurobi(rnd_seed, n_obj, params, params_opt, num_samples=20, no_cat=False
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_gurobi_consistency1(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        }
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
     params_opt = {"LogToConsole": 1, "MIPGap": 0}
     run_gurobi(rnd_seed, n_obj, params, params_opt, num_samples=200)
 
@@ -88,15 +89,15 @@ def test_gurobi_consistency1(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_gurobi_consistency2(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        },
-    }
-    params["unc_params"]["beta"] = 0.05
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
+    params.unc_params.beta = 0.05
     params_opt = {"LogToConsole": 1, "MIPGap": 0}
 
     run_gurobi(rnd_seed, n_obj, params, params_opt, num_samples=300)
@@ -109,26 +110,31 @@ def test_gurobi_consistency2(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_gurobi_consistency3(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "normal",
-        "cat_metric": cat_metric,
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric
+        ),
 
-    # make tree model smaller to reduce testing time
-    params["tree_train_params"] = {
-        "objective": "regression",
-        "metric": "rmse",
-        "boosting": "gbdt",
-        "num_boost_round": 2,
-        "max_depth": 2,
-        "min_data_in_leaf": 1,
-        "min_data_per_group": 1,
-        "verbose": -1,
-    }
-    params["unc_params"]["beta"] = 0.05
+        # make tree model smaller to reduce testing time
+        tree_train_params=TreeTrainParams(
+            train_lib="lgbm",
+            train_params=TrainParams(
+                objective="regression",
+                metric="rmse",
+                boosting="gbdt",
+                num_boost_round=2,
+                max_depth=2,
+                min_data_in_leaf=1,
+                min_data_per_group=1,
+                verbose=-1
+            )
+        )
+    )
+
+    params.unc_params.beta = 0.05
     params_opt = {"LogToConsole": 1}
 
     if n_obj == 1:
@@ -144,13 +150,15 @@ def test_gurobi_consistency3(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric
 @pytest.mark.parametrize("acq_sense", ["exploration"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
 def test_gurobi_consistency4(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.1
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+
+    params.unc_params.beta = 0.1
     params_opt = {"LogToConsole": 1, "MIPGap": 1e-5}
 
     run_gurobi(rnd_seed, 1, params, params_opt, num_samples=20, no_cat=True)
@@ -160,13 +168,14 @@ def test_gurobi_consistency4(rnd_seed, acq_sense, dist_metric):
 @pytest.mark.parametrize("acq_sense", ["penalty"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
 def test_gurobi_consistency5(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.1
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+    params.unc_params.beta = 0.1
     params_opt = {"LogToConsole": 1, "MIPGap": 1e-5}
 
     run_gurobi(rnd_seed, 1, params, params_opt, num_samples=200, no_cat=True)
@@ -176,13 +185,14 @@ def test_gurobi_consistency5(rnd_seed, acq_sense, dist_metric):
 @pytest.mark.parametrize("acq_sense", ["penalty"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
 def test_gurobi_consistency6(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.05
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+    params.unc_params.beta = 0.05
     params_opt = {"LogToConsole": 1, "MIPGapAbs": 0.01}
 
     run_gurobi(rnd_seed, 1, params, params_opt, num_samples=200, no_cat=True)

--- a/tests/test_consistency_pyomo.py
+++ b/tests/test_consistency_pyomo.py
@@ -4,6 +4,7 @@ import random
 import math
 
 from entmoot import Enting, ProblemConfig, PyomoOptimizer
+from entmoot.models.model_params import EntingParams, UncParams, TreeTrainParams, TrainParams
 from entmoot.benchmarks import (
     build_multi_obj_categorical_problem,
     eval_multi_obj_cat_testfunc,
@@ -71,14 +72,14 @@ def run_pyomo(rnd_seed, n_obj, params, params_opt, num_samples=20, no_cat=False)
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_pyomo_consistency1(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        }
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"NonConvex": 2, "MIPGap": 0},
@@ -93,15 +94,15 @@ def test_pyomo_consistency1(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric)
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_gurobi_consistency2(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        },
-    }
-    params["unc_params"]["beta"] = 0.05
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
+    params.unc_params.beta = 0.05
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"NonConvex": 2, "MIPGap": 0},
@@ -117,26 +118,31 @@ def test_gurobi_consistency2(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric
 @pytest.mark.parametrize("n_obj", [1, 2])
 def test_pyomo_consistency3(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "normal",
-        "cat_metric": cat_metric,
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric
+        ),
 
-    # make tree model smaller to reduce testing time
-    params["tree_train_params"] = {
-        "objective": "regression",
-        "metric": "rmse",
-        "boosting": "gbdt",
-        "num_boost_round": 2,
-        "max_depth": 2,
-        "min_data_in_leaf": 1,
-        "min_data_per_group": 1,
-        "verbose": -1,
-    }
-    params["unc_params"]["beta"] = 0.05
+        # make tree model smaller to reduce testing time
+        tree_train_params=TreeTrainParams(
+            train_lib="lgbm",
+            train_params=TrainParams(
+                objective="regression",
+                metric="rmse",
+                boosting="gbdt",
+                num_boost_round=2,
+                max_depth=2,
+                min_data_in_leaf=1,
+                min_data_per_group=1,
+                verbose=-1
+            )
+        )
+    )
+
+    params.unc_params.beta = 0.05
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"MIPGap": 0, "LogToConsole": 1, "NonConvex": 2},
@@ -154,14 +160,16 @@ def test_pyomo_consistency3(rnd_seed, n_obj, acq_sense, dist_metric, cat_metric)
 @pytest.mark.parametrize("dist_metric", ["l1", "l2", "euclidean_squared"])
 @pytest.mark.parametrize("acq_sense", ["exploration"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
-def test_gurobi_consistency4(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.1
+def test_pyomo_consistency4(rnd_seed, acq_sense, dist_metric):
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+
+    params.unc_params.beta = 0.1
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"NonConvex": 2, "MIPGap": 1e-5},
@@ -173,14 +181,15 @@ def test_gurobi_consistency4(rnd_seed, acq_sense, dist_metric):
 @pytest.mark.parametrize("dist_metric", ["l1", "euclidean_squared"])
 @pytest.mark.parametrize("acq_sense", ["penalty"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
-def test_gurobi_consistency5(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.1
+def test_pyomo_consistency5(rnd_seed, acq_sense, dist_metric):
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+    params.unc_params.beta = 0.1
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"NonConvex": 2, "MIPGap": 1e-5},
@@ -192,14 +201,15 @@ def test_gurobi_consistency5(rnd_seed, acq_sense, dist_metric):
 @pytest.mark.parametrize("dist_metric", ["l2"])
 @pytest.mark.parametrize("acq_sense", ["penalty"])
 @pytest.mark.parametrize("rnd_seed", [100, 101, 102])
-def test_gurobi_consistency6(rnd_seed, acq_sense, dist_metric):
-    params = {}
-    params["unc_params"] = {
-        "dist_metric": dist_metric,
-        "acq_sense": acq_sense,
-        "dist_trafo": "standard",
-    }
-    params["unc_params"]["beta"] = 0.05
+def test_pyomo_consistency6(rnd_seed, acq_sense, dist_metric):
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="standard",
+        )
+    )
+    params.unc_params.beta = 0.05
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"NonConvex": 2, "MIPGap": 1e-5},

--- a/tests/test_curr.py
+++ b/tests/test_curr.py
@@ -1,6 +1,7 @@
 import math
 
 from entmoot import Enting, ProblemConfig, GurobiOptimizer, PyomoOptimizer
+from entmoot.models.model_params import EntingParams, UncParams
 from entmoot.benchmarks import (
     build_multi_obj_categorical_problem,
     eval_multi_obj_cat_testfunc,
@@ -42,7 +43,10 @@ def test_multiobj_constraints():
     rnd_sample = problem_config.get_rnd_sample_list(num_samples=20)
     testfunc_evals = eval_multi_obj_cat_testfunc(rnd_sample, n_obj=number_objectives)
 
-    params = {"unc_params": {"dist_metric": "l1", "acq_sense": "exploration"}}
+    params = EntingParams(unc_params=UncParams(
+        dist_metric="l1",
+        acq_sense="exploration"
+    ))
     enting = Enting(problem_config, params=params)
     # fit tree ensemble
     enting.fit(rnd_sample, testfunc_evals)
@@ -107,7 +111,10 @@ def test_simple_test():
     y_train = np.reshape([my_func(x) for x in X_train], (-1, 1))
 
     # Define enting object and corresponding parameters
-    params = {"unc_params": {"dist_metric": "l1", "acq_sense": "penalty"}}
+    params = EntingParams(unc_params=UncParams(
+        dist_metric="l1",
+        acq_sense="exploration"
+    ))
     enting = Enting(problem_config, params=params)
     # Fit tree model
     enting.fit(X_train, y_train)
@@ -138,7 +145,10 @@ def test_compare_pyomo_gurobipy_multiobj():
 
     for metric in ["l1", "l2", "euclidean_squared"]:
         for acq_sense in ["exploration", "penalty"]:
-            params = {"unc_params": {"dist_metric": metric, "acq_sense": acq_sense}}
+            params = EntingParams(unc_params=UncParams(
+                dist_metric=metric,
+                acq_sense=acq_sense
+            ))
             enting = Enting(problem_config, params=params)
             # fit tree ensemble
             enting.fit(rnd_sample, testfunc_evals)
@@ -179,7 +189,10 @@ def test_compare_pyomo_gurobipy_singleobj():
 
     for metric in ["l1", "l2", "euclidean_squared"]:
         for acq_sense in ["exploration", "penalty"]:
-            params = {"unc_params": {"dist_metric": metric, "acq_sense": acq_sense}}
+            params = EntingParams(unc_params=UncParams(
+                dist_metric=metric,
+                acq_sense=acq_sense
+            ))            
             enting = Enting(problem_config, params=params)
             # fit tree ensemble
             enting.fit(rnd_sample, testfunc_evals)

--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -1,0 +1,30 @@
+from entmoot.models.model_params import EntingParams, ParamValidationError
+import pytest
+
+def test_model_params_creation():
+    """Check EntingParams is instantiated correctly, and check default values."""
+    params = EntingParams(**{
+        "unc_params": {"beta": 2},
+        "tree_train_params" : {
+            "train_params": {"max_depth": 5}
+            }
+    })
+
+    assert params.unc_params.beta == 2
+    assert params.tree_train_params.train_params.max_depth == 5
+
+    # check a selection of defaults
+    assert params.unc_params.acq_sense in ("exploration", "penalty")
+    assert params.tree_train_params.train_params.min_data_in_leaf == 1
+
+
+def test_model_params_invalid_values():
+    """Check EntingParams raises an error for invalid values."""
+    with pytest.raises(ParamValidationError):
+        _ = EntingParams(**{"unc_params": {"beta": -1}})
+
+    with pytest.raises(ParamValidationError):
+        _ = EntingParams(**{"tree_train_params": {"train_lib": "notimplementedlib"}})
+
+    with pytest.raises(ParamValidationError):
+        _ = EntingParams(**{"unc_params": {"acq_sense": "notimplementedsense"}})

--- a/tests/test_model_params.py
+++ b/tests/test_model_params.py
@@ -1,4 +1,4 @@
-from entmoot.models.model_params import EntingParams, ParamValidationError
+from entmoot.models.model_params import EntingParams, UncParams, TrainParams, TreeTrainParams, ParamValidationError
 import pytest
 
 def test_model_params_creation():
@@ -16,6 +16,15 @@ def test_model_params_creation():
     # check a selection of defaults
     assert params.unc_params.acq_sense in ("exploration", "penalty")
     assert params.tree_train_params.train_params.min_data_in_leaf == 1
+
+    # check alternate initialisation method
+    params_other = EntingParams(
+        unc_params=UncParams(beta=2),
+        tree_train_params=TreeTrainParams(
+            train_params=TrainParams(max_depth=5)
+        )
+    )
+    assert params == params_other
 
 
 def test_model_params_invalid_values():

--- a/tests/test_optimality_gurobi.py
+++ b/tests/test_optimality_gurobi.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 
 from entmoot import Enting, ProblemConfig, GurobiOptimizer
+from entmoot.models.model_params import EntingParams, UncParams
 from entmoot.benchmarks import (
     build_multi_obj_categorical_problem,
     eval_multi_obj_cat_testfunc,
@@ -91,13 +92,13 @@ def run_gurobi(
 @pytest.mark.parametrize("rnd_seed", [100, 101])
 def test_gurobi_optimality(rnd_seed, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        }
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
     params_opt = {"LogToConsole": 1, "MIPGap": 0}
     run_gurobi(rnd_seed, params, params_opt, num_samples=20)

--- a/tests/test_optimality_pyomo.py
+++ b/tests/test_optimality_pyomo.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 
 from entmoot import Enting, ProblemConfig, PyomoOptimizer
+from entmoot.models.model_params import EntingParams, UncParams
 from entmoot.benchmarks import (
     build_multi_obj_categorical_problem,
     eval_multi_obj_cat_testfunc,
@@ -91,14 +92,14 @@ def run_pyomo(
 @pytest.mark.parametrize("rnd_seed", [100, 101])
 def test_pyomo_optimality(rnd_seed, acq_sense, dist_metric, cat_metric):
     # define model params
-    params = {
-        "unc_params": {
-            "dist_metric": dist_metric,
-            "acq_sense": acq_sense,
-            "dist_trafo": "normal",
-            "cat_metric": cat_metric,
-        }
-    }
+    params = EntingParams(
+        unc_params=UncParams(
+            dist_metric=dist_metric,
+            acq_sense=acq_sense,
+            dist_trafo="normal",
+            cat_metric=cat_metric,
+        )
+    )
     params_opt = {
         "solver_name": "gurobi",
         "solver_options": {"MIPGap": 0, "LogToConsole": 1, "NonConvex": 2},


### PR DESCRIPTION
 This address issues #19 and #23, providing a typed `dataclass` for the Enting parameters, as well as a helper function for constructing from a dictionary (to not break existing uses). I haven't changed the bulk of the Enting code to use this dataclass since I wanted to first see whether this approach is the best. Some alternatives that I considered that don't work as well as dataclasses:

- `TypedDict` - this doesn't support default values
- `namedtuple` - this isn't really designed for large structured objects, and would be quite clunky to use.
- `pydantic` - this would provide much stronger typing, however it would require a lot of effort to implement for the whole project.
- other pip modules - there are a few modules out there that do something similar, but I didn't want to add more dependencies to the project.

Let me know what you think! 