### PR TITLE
Enable Cloud Gurobi integration with solver factory params in pyomo

### DIFF
--- a/entmoot/optimizers/pyomo_opt.py
+++ b/entmoot/optimizers/pyomo_opt.py
@@ -85,7 +85,11 @@ class PyomoOptimizer:
             assert sum(weights) == 1.0, "weights don't add up to 1.0"
 
         # choose solver
-        opt = pyo.SolverFactory(self._params["solver_name"])
+        opt = pyo.SolverFactory(
+            self._params["solver_name"],
+            manage_env="solver_factory_options" in self._params,
+            options=self._params.get("solver_factory_options", {}),
+        )
 
         # set solver parameters
         if "solver_options" in self._params:


### PR DESCRIPTION
This PR adds an additional option to `solver_params`, in the form of `solver_factory_params`. These are parameters that are added to the solver **at creation time**. This is relevant in the following example:

When using Gurobi Cloud, you must set the cloud parameters at creation time. Passing in these after creation does nothing, since the environment is already created to be the local environment.

To use this, during the creation of an optimizer, the `params` dictionary that is passed to the Optimizer should include the following:

```python
params["solver_factory_options"] = {
      "CloudAccessID": "<access-id>",
      "CloudSecretKey": "<api-key>",
}
```