### PR TITLE
Binary features now allow bounds

### DIFF
--- a/entmoot/problem_config.py
+++ b/entmoot/problem_config.py
@@ -284,10 +284,11 @@ class ProblemConfig:
         if name is None:
             name = f"feat_{len(self.feat_list)}"
 
+        if feat_type == "binary":
+            self._feat_list.append(Binary(name=name))
+            return
+
         if bounds is None:
-            if feat_type == "binary":
-                self._feat_list.append(Binary(name=name))
-                return
             raise ValueError(
                 "Please provide bounds for feature types in '(real, integer, categorical)'"
             )


### PR DESCRIPTION
Previously, the logic in `problem_config.py` enforced binary features to have `bounds is None`. We now allow `bounds` to be passed, and it is simply ignored.

Fixes https://github.com/experimental-design/bofire/pull/464