### PR TITLE
Pin gurobipy dev version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 numpy<2.0.0
 lightgbm>=4.0.0
 pyomo==6.7.1
-gurobipy
+gurobipy<12.0.0
 pytest-cov
 IPython
 nbsphinx


### PR DESCRIPTION
The test pipeline was failing as gurobipy dev version was not pinned to <12