### PR TITLE
Bump numpy and pyomo

### DIFF
--- a/entmoot/__version__.py
+++ b/entmoot/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 __author__ = "Alexander Thebelt"
 __author_email__ = "alexander.thebelt18@imperial.ac.uk"
 __license__ = "BSD 3-Clause License"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-numpy<2.0.0
-lightgbm>=4.0.0
+numpy~=2.0.0
+lightgbm~=4.6.0
 pyomo==6.7.1
 gurobipy<12.0.0
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 numpy~=2.0.0
 lightgbm~=4.6.0
-pyomo==6.7.1
+pyomo~=6.9.0
 gurobipy<12.0.0
 pytest-cov
 IPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=2.0.0
 lightgbm~=4.6.0
 gurobipy<12.0.0
-pyomo==6.7.1
+pyomo~=6.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<2.0.0
-lightgbm>=4.0.0
+numpy~=2.0.0
+lightgbm~=4.6.0
 gurobipy<12.0.0
 pyomo==6.7.1

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,14 @@ setup(
     url="https://github.com/cog-imperial/entmoot",
     packages=find_packages(exclude=["tests", "docs"]),
     install_requires=[
-        "numpy<=2.0.0",
-        "lightgbm>=4.0.0",
+        "numpy~=2.0.0",
+        "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
         "pyomo==6.7.1",
     ],
     setup_requires=[
-        "numpy<=2.0.0",
-        "lightgbm>=4.0.0",
+        "numpy~=2.0.0",
+        "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
         "pyomo==6.7.1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ setup(
         "numpy~=2.0.0",
         "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
-        "pyomo==6.7.1",
+        "pyomo~=6.9.0",
     ],
     setup_requires=[
         "numpy~=2.0.0",
         "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
-        "pyomo==6.7.1",
+        "pyomo~=6.9",
     ],
 )


### PR DESCRIPTION
We had previously pinned `pyomo==6.7.1` due to a change in 6.7.2 that broke our interface with Gurobi. However, 6.9.0 seems to have fixed that change, and we would like to drop this pin to allow `numpy` to update as well.