### PR TITLE
Unpin numpy version

### DIFF
--- a/entmoot/__version__.py
+++ b/entmoot/__version__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 __author__ = "Alexander Thebelt"
 __author_email__ = "alexander.thebelt18@imperial.ac.uk"
 __license__ = "BSD 3-Clause License"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy~=2.0.0
+numpy
 lightgbm~=4.6.0
 pyomo~=6.9.0
 gurobipy<12.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy~=2.0.0
+numpy
 lightgbm~=4.6.0
 gurobipy<12.0.0
 pyomo~=6.9.0

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ setup(
     url="https://github.com/cog-imperial/entmoot",
     packages=find_packages(exclude=["tests", "docs"]),
     install_requires=[
-        "numpy~=2.0.0",
+        "numpy",
         "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
         "pyomo~=6.9.0",
     ],
     setup_requires=[
-        "numpy~=2.0.0",
+        "numpy",
         "lightgbm~=4.6.0",
         "gurobipy<12.0.0",
-        "pyomo~=6.9",
+        "pyomo~=6.9.0",
     ],
 )


### PR DESCRIPTION
When used with some other packages (eg. `mordred`, which is a dependency in BoFire), adding a pin to the numpy version introduced unresolvable dependencies. Since Entmoot is agnostic to the version of numpy (as far as I can tell), I am removing the pin to numpy 2.